### PR TITLE
added podspec for rn 0.61 compatibility.

### DIFF
--- a/example/ios/react-native-iot-wifi.podspec
+++ b/example/ios/react-native-iot-wifi.podspec
@@ -1,0 +1,17 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, '../package.json')))
+
+Pod::Spec.new do |s|
+  s.name         = package['react-native-iot-wifi']
+  s.version      = package['1.0.1']
+  s.summary      = package['description']
+  s.license      = package['MIT License']
+
+  s.authors      = package['tadasr', 'edpaget', 'saurabytes', 'tongentilcore', 'josectobar']
+  s.homepage     = package['homepage']
+  s.platform     = :ios, "9.0"
+
+  s.source       = { :git => "https://github.com/josectobar/react-native-iot-wifi.git", :tag => "#{s.version}" }
+  s.source_files  = "ios/**/*.{h,m}"
+end 


### PR DESCRIPTION
This merge aims to enable compatibility with RN v 0.61.2 which requires 3rd party libs to be install through pods for iOS.